### PR TITLE
Use allJvmArgs instead of jvmArgs

### DIFF
--- a/src/main/groovy/baseline/launchconfig/EclipseLaunchConfigTask.groovy
+++ b/src/main/groovy/baseline/launchconfig/EclipseLaunchConfigTask.groovy
@@ -71,7 +71,7 @@ class EclipseLaunchConfigTask extends DefaultTask {
 
             stringAttribute(
                     key: "org.eclipse.jdt.launching.VM_ARGUMENTS",
-                    value: javaExec.jvmArgs.join(" "))
+                    value: javaExec.allJvmArgs.join(" "))
 
             stringAttribute(
                     key: "org.eclipse.jdt.launching.PROJECT_ATTR",

--- a/src/main/groovy/baseline/launchconfig/IdeaLaunchConfigTask.groovy
+++ b/src/main/groovy/baseline/launchconfig/IdeaLaunchConfigTask.groovy
@@ -62,7 +62,7 @@ class IdeaLaunchConfigTask extends DefaultTask {
         runManager.appendNode('configuration', [default: 'false', name: determineRunConfigName(javaExec), type: 'Application', factoryName: 'Application'], [
                 new Node(null, 'extension', [name: 'coverage', enabled: 'false', merge: 'false', runner: 'idea']),
                 new Node(null, 'option', [name: 'MAIN_CLASS_NAME', value: javaExec.main]),
-                new Node(null, 'option', [name: 'VM_PARAMETERS', value: javaExec.jvmArgs.join(" ")]),
+                new Node(null, 'option', [name: 'VM_PARAMETERS', value: javaExec.allJvmArgs.join(" ")]),
                 new Node(null, 'option', [name: 'PROGRAM_PARAMETERS', value: javaExec.args.join(" ")]),
                 new Node(null, 'option', [name: 'WORKING_DIRECTORY', value: javaExec.workingDir]),
                 new Node(null, 'option', [name: 'ALTERNATIVE_JRE_PATH_ENABLED', value: 'false']),

--- a/src/test/groovy/baseline/launchconfig/EclipseLaunchConfigTaskIntegrationSpec.groovy
+++ b/src/test/groovy/baseline/launchconfig/EclipseLaunchConfigTaskIntegrationSpec.groovy
@@ -46,7 +46,7 @@ class EclipseLaunchConfigTaskIntegrationSpec extends IntegrationSpec {
                 classpath project.sourceSets.main.runtimeClasspath
                 main '${main}'
                 args('server', 'dev/conf/server.yml')
-                jvmArgs('-server', '-client')
+                jvmArgs('-server', '-client', '-Ddw.assets')
                 workingDir '/'
             }
         """.stripIndent()
@@ -70,7 +70,11 @@ class EclipseLaunchConfigTaskIntegrationSpec extends IntegrationSpec {
         }
 
         xml.stringAttribute.any {
-            it.@key == "org.eclipse.jdt.launching.VM_ARGUMENTS" && it.@value == "-server -client"
+            it.@key == "org.eclipse.jdt.launching.VM_ARGUMENTS" && it.@value.toString().indexOf("-server -client") > -1
+        }
+
+        xml.stringAttribute.any {
+            it.@key == "org.eclipse.jdt.launching.VM_ARGUMENTS" && it.@value.toString().indexOf("-Ddw.assets") > -1
         }
 
         xml.stringAttribute.any {

--- a/src/test/groovy/baseline/launchconfig/IdeaLaunchConfigTaskIntegrationSpec.groovy
+++ b/src/test/groovy/baseline/launchconfig/IdeaLaunchConfigTaskIntegrationSpec.groovy
@@ -46,7 +46,7 @@ class IdeaLaunchConfigTaskIntegrationSpec extends IntegrationSpec {
                 classpath project.sourceSets.main.runtimeClasspath
                 main '${main}'
                 args('server', 'dev/conf/server.yml')
-                jvmArgs('-server', '-client')
+                jvmArgs('-server', '-client', '-Ddw.assets')
                 workingDir '/'
             }
         """.stripIndent()
@@ -68,7 +68,8 @@ class IdeaLaunchConfigTaskIntegrationSpec extends IntegrationSpec {
         runConfig != null
 
         runConfig.option.any { it.@name == "MAIN_CLASS_NAME" && it.@value == main }
-        runConfig.option.any { it.@name == "VM_PARAMETERS" && it.@value == "-server -client" }
+        runConfig.option.any { it.@name == "VM_PARAMETERS" && it.@value.toString().indexOf("-server -client") > -1 }
+        runConfig.option.any { it.@name == "VM_PARAMETERS" && it.@value.toString().indexOf("-Ddw.assets") > -1 }
         runConfig.option.any { it.@name == "PROGRAM_PARAMETERS" && it.@value == "server dev/conf/server.yml" }
         runConfig.option.any { it.@name == "WORKING_DIRECTORY" && it.@value == "/" }
         runConfig.module.any { it.@name == this.projectName }


### PR DESCRIPTION
This allows system properties to be passed from gradle into a launch
config.

A common pattern is to use DW overrides to create custom runTasks. DW
overrides are passed as system properties, and thus don't get picked up
without this commit.